### PR TITLE
Add HTTP level log triggering config

### DIFF
--- a/src/DependencyInjection/ApiResponseExtension.php
+++ b/src/DependencyInjection/ApiResponseExtension.php
@@ -27,6 +27,7 @@ class ApiResponseExtension extends ConfigurableExtension
         $defaults = isset($mergedConfig['defaults']) ? $mergedConfig['defaults'] : [];
 
         $paths = $mergedConfig['paths'];
+        $logTrigger = $mergedConfig['log_trigger'];
 
 //        $configCompiler = new ApiConfigCompiler($defaultConfig, $pathConfigs);
 //        $container->set('api_response.compiler.api_config', $configCompiler);
@@ -39,6 +40,7 @@ class ApiResponseExtension extends ConfigurableExtension
 
         $container->setParameter('api_response.defaults', $defaults);
         $container->setParameter('api_response.paths', $paths);
+        $container->setParameter('api_response.log_trigger', $logTrigger);
 
         // Load the rest of the services.
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,6 +6,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * API Response Bundle Configuration
@@ -25,6 +26,14 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('api_response');
+
+        $rootNode
+            ->children()
+                ->integerNode('log_trigger')
+                    ->info('Minimum HTTP return status code which triggers response exception logging.')
+                    ->defaultValue(Response::HTTP_INTERNAL_SERVER_ERROR)
+                ->end()
+            ->end();
 
         $this->buildConfigNode(
             $rootNode

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,6 +20,7 @@ services:
             - "@api_response.compiler.api_config"
             - "@logger"
             - %kernel.debug%
+            - %api_response.log_trigger%
 
     # Factory
     api_response.factory.serializer_adapter:


### PR DESCRIPTION
Allow the logging of error responses to be triggered by an optional config value.

```
api_response:
    log_trigger: 400
```

This would cause all error responses with HTTP codes of 400 or greater to be logged.

The default value is 500.